### PR TITLE
Update Shadertoy-VDB.frag

### DIFF
--- a/Include/Shadertoy-VDB.frag
+++ b/Include/Shadertoy-VDB.frag
@@ -1,3 +1,6 @@
+#version 330
+precision highp float;
+precision highp int;
 #donotrun
 #buffer RGBA32F
 #buffershader "Shadertoy-VDB-BufferShader.frag"

--- a/Include/Shadertoy-VDB.frag
+++ b/Include/Shadertoy-VDB.frag
@@ -1,4 +1,3 @@
-#version 130
 #donotrun
 #buffer RGBA32F
 #buffershader "Shadertoy-VDB-BufferShader.frag"


### PR DESCRIPTION
Remove #version directive, it should be used in the fragment shaders themselves